### PR TITLE
fix typo and minor bug

### DIFF
--- a/train.py
+++ b/train.py
@@ -124,7 +124,7 @@ class FastestDet:
                 self.model.eval()
                 print("computer mAP...")
                 mAP05 = self.evaluation.compute_map(self.val_dataloader, self.model)
-                torch.save(self.model.state_dict(), "checkpoint/weight_AP05:%f_%d-epoch.pth"%(mAP05, epoch))
+                torch.save(self.model.state_dict(), "checkpoint/weight_AP05_%f_%d-epoch.pth"%(mAP05, epoch))
 
             # 学习率调整
             self.scheduler.step()

--- a/utils/datasets.py
+++ b/utils/datasets.py
@@ -58,11 +58,11 @@ class TensorDataset():
                     else:
                         self.data_list.append(data_path)
                 else:
-                    raise Exception("%s is not exist" % data_path)
+                    raise Exception("%s does not exist" % data_path)
 
     def __getitem__(self, index):
         img_path = self.data_list[index]
-        label_path = img_path.split(".")[0] + ".txt"
+        label_path = '.'.join(img_path.split(".")[:-1]) + ".txt"
 
         # 加载图片
         img = cv2.imread(img_path)
@@ -80,7 +80,7 @@ class TensorDataset():
                 #assert (label >= 0).all(), 'negative labels: %s'%label_path
                 #assert (label[:, 1:] <= 1).all(), 'non-normalized or out of bounds coordinate labels: %s'%label_path
         else:
-            raise Exception("%s is not exist" % label_path) 
+            raise Exception("%s does not exist" % label_path) 
 
         # 是否进行数据增强
         if self.aug:


### PR DESCRIPTION
Current `dataset.py` assumes that the file name only contains a single dot, this would cause problem if dataset file name is `a.b.c.jpg` and it will go for label `a.txt`

目前的数据处理环节假设文件名仅存在一个点，当图像文件名存在多个点时会寻找错误的标签文件